### PR TITLE
Moved a lot of logic into Task from FormalTask.

### DIFF
--- a/configs.py
+++ b/configs.py
@@ -13,6 +13,7 @@ A config can be run with:
 """
 
 from formalisms.cfg import *
+from stacknn_utils.data_readers import *
 from tasks import *
 from torch.nn import CrossEntropyLoss
 
@@ -262,4 +263,13 @@ anb2n_config = {
     "task": OrderedCountingTask,
     "length_fns": [lambda n: n, lambda n: 2 * n],
     "hidden_size": 1,
+}
+
+"""Tasks using datasets."""
+
+linzen_agreement_config = {
+    "task": NaturalTask,
+    "train_filename": "../data/linzen/rnn_arg_simple/numpred.test.5",
+    "test_filename": "../data/linzen/rnn_arg_simple/numpred.test.5",
+    "data_reader": ByLineDatasetReader(linzen_line_consumer),
 }

--- a/stacknn_utils/data_readers.py
+++ b/stacknn_utils/data_readers.py
@@ -41,6 +41,10 @@ class ByLineDatasetReader(object):
 			Y.append(y)
 		return X, Y
 
+	def reset_counts(self):
+		self._max_x_length = 0
+		self._max_y_length = min(self._max_y_length, -1)
+
 	@property
 	def max_x_length(self):
 		"""The length of the longest-seen input."""

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -3,3 +3,4 @@ from cfg import CFGTask, CFGTransduceTask
 from counting import OrderedCountingTask
 from reverse import ReverseTask, CopyTask, ReverseDeletionTask
 from evaluation import EvaluationTask, XORTask, DelayedXORTask
+from natural import NaturalTask

--- a/tasks/cfg.py
+++ b/tasks/cfg.py
@@ -47,8 +47,6 @@ class CFGTask(LanguageModelingTask):
 
 
     def __init__(self, params):
-        # FIXME: Does not converge on several configs.
-        # Checked: to_predict, production of strings, loss_fn
         super(CFGTask, self).__init__(params)
         print "Sample depth: %d" % self.sample_depth
         print "Max length: %d" % self.max_length
@@ -62,30 +60,13 @@ class CFGTask(LanguageModelingTask):
         print "Maximum sample length: " + str(max_sample_length)
         print "Maximum input length: " + str(self.max_x_length)
 
-    def reset_model(self, model_type, controller_type, struct_type, **kwargs):
-        """
-        Instantiates a neural network model of a given type that is
-        compatible with this Task. This function must set self.model to
-        an instance of model_type.
+    @property
+    def input_size(self):
+        return self.alphabet_size
 
-        :type model_type: type
-        :param model_type: The type of the Model used in this Task
-
-        :type controller_type: type
-        :param controller_type: The type of the Controller that will perform
-            the neural network computations
-
-        :type struct_type: type
-        :param struct_type: The type of neural data structure that this
-            Model will operate
-
-        :return: None
-        """
-        self.model = model_type(self.alphabet_size, self.read_size,
-                                self.alphabet_size,
-                                controller_type=controller_type,
-                                struct_type=struct_type,
-                                **kwargs)
+    @property
+    def output_size(self):
+        return self.alphabet_size
 
     def _init_alphabet(self, null):
         """

--- a/tasks/counting.py
+++ b/tasks/counting.py
@@ -61,13 +61,13 @@ class OrderedCountingTask(LanguageModelingTask):
 
     """ Core Logic """
 
-    def reset_model(self, model_type, controller_type, struct_type, **kwargs):
-        self.model = model_type(self.alphabet_size,
-                                self.read_size,
-                                self.alphabet_size,
-                                controller_type=controller_type,
-                                struct_type=struct_type,
-                                **kwargs)
+    @property
+    def input_size(self):
+        return self.alphabet_size
+
+    @property
+    def output_size(self):
+        return self.alphabet_size
 
     def _init_alphabet(self, null):
         x_length = len(self.length_fns)

--- a/tasks/evaluation.py
+++ b/tasks/evaluation.py
@@ -16,12 +16,13 @@ from structs import Stack
 
 
 class EvaluationTask(FormalTask):
+
     """
     Abstract class for experiments where the controller is incrementally
     fed a sequence and at every iteration has to evaluate a given
     function over all the sequence elements it has seen by that point.
     """
-    
+
 
     class Params(FormalTask.Params):
 
@@ -33,32 +34,13 @@ class EvaluationTask(FormalTask):
             self.max_y_length = self.max_length
 
 
-    def reset_model(self, model_type, controller_type, struct_type,
-                    reg_weight=1., **kwargs):
-        """
-        Instantiates a neural network model of a given type that is
-        compatible with this Task. This function must set self.model to
-        an instance of model_type
+    @property
+    def input_size(self):
+        return self.alphabet_size
 
-        :type model_type: type
-        :param model_type: A type from the models package
-
-        :type controller_type: type
-        :param controller_type: The type of the Controller that will perform
-            the neural network computations
-
-        :type struct_type: type
-        :param struct_type: The type of neural data structure that this
-            Model will operate
-
-        :return: None
-        """
-        self.model = model_type(self.alphabet_size,
-                                self.read_size,
-                                self.alphabet_size,
-                                controller_type=controller_type,
-                                struct_type=struct_type,
-                                reg_weight=reg_weight)
+    @property
+    def output_size(self):
+        return self.alphabet_size
 
     def _init_alphabet(self, null):
         return {u"0": 0, u"1": 1, u"2": 2}
@@ -232,6 +214,7 @@ class XORTask(EvaluationTask):
             super(XORTask.Params, self).__init__(max_length=self.str_length,
                                                  time_function=time_function,
                                                  **kwargs)
+
 
     """ Model Training """
 

--- a/tasks/natural.py
+++ b/tasks/natural.py
@@ -20,47 +20,35 @@ class NaturalTask(Task):
     DataFrame and then used to train a model.
     """
 
-    # TODO(lambdaviking): Write this class here.
+    
+    class Params(Task.Params):
 
-    def __init__(self, train_filename, test_filename, data_reader, **args):
-        self._train_filename = train_filename
-        self._test_filename = test_filename
-        self._data_reader = data_reader
-        super(NaturalTask, self).__init__(**args)
+        def __init__(self, train_filename, test_filename, data_reader, **kwargs):
+            self.train_filename = train_filename
+            self.test_filename = test_filename
+            self.data_reader = data_reader
+            self.max_num_embeddings = kwargs.get("max_num_embeddings", 5000)
+            self.max_num_output_classes = kwargs.get("max_num_output_classes", 2)
+            super(NaturalTask.Params, self).__init__(**kwargs)
 
-    def reset_model(self, model_type, controller_type, struct_type):
-        # TODO(lambdaviking): Implement this.
-        pass
+
+    @property
+    def input_size(self):
+        return self.max_num_embeddings
+
+    @property
+    def output_size(self):
+        return self.max_num_output_classes
 
     def get_data(self):
-        train_x, train_y = self._data_reader.read_x_and_y(self.train_filename)
-        test_x, test_y = self._data_reader.read_x_and_y(self.test_filename)
+        self.data_reader.reset_counts()
 
-        max_length = self._data_reader.max_x_length
+        train_x, train_y = self.data_reader.read_x_and_y(self.train_filename)
+        test_x, test_y = self.data_reader.read_x_and_y(self.test_filename)
+
+        max_length = self.data_reader.max_x_length
         pad = lambda line: np.pad(line, max_length, "constant")
         train_x = array_map(pad, train_x)
         test_x = array_map(pad, test_x)
 
         print(train_x)
-
-        # TODO: Map words to integers.
-
-    def _init_alphabet(self, null):
-        """Task doesn't fit desired design pattern for this method."""
-        return None
-
-    def _evaluate_step(self, x, y, a, j):
-        pass
-
-    def generic_example(self):
-        pass
-
-
-@testcase(DataFrameTask)
-def test_get_data():
-    from stacknn_utils.data_readers import ByLineDatasetReader, linzen_line_consumer
-    filename = "../data/linzen/rnn_arg_simple/numpred.test.5"
-    data_reader = ByLineDatasetReader(linzen_line_consumer)
-    task = NaturalTask(filename, filename, data_reader)
-    task.get_data()
-

--- a/tasks/reverse.py
+++ b/tasks/reverse.py
@@ -32,16 +32,14 @@ class ReverseTask(FormalTask):
             self.max_x_length = self.max_length * 2
             self.max_y_length = self.max_length * 8
 
-            # This does not run properly.
 
+    @property
+    def input_size(self):
+        return self.alphabet_size
 
-    def reset_model(self, model_type, controller_type, struct_type, **kwargs):
-        self.model = model_type(self.alphabet_size,
-                                self.read_size,
-                                self.alphabet_size,
-                                controller_type=controller_type,
-                                struct_type=struct_type,
-                                **kwargs)
+    @property
+    def output_size(self):
+        return self.alphabet_size
 
     def _init_alphabet(self, null):
         return {unicode(i): i for i in xrange(self.num_symbols + 1)}


### PR DESCRIPTION
In the process of writing a Task that we can train on real data, I moved a bunch of logic into a root abstract class Task.

Now, we have two subclasses `FormalTask` and `NaturalTask`.

`FormalTask` is abstract, and formal language tasks should extend it.

`NaturalTask` will be concrete, and can be instantiated to hold a dataset.